### PR TITLE
Add Synchronic SAM-SE Plugin version v1.3.0

### DIFF
--- a/KeyManager.Library.KeyStore.SAM_SE/SAM_SEKeyStore.cs
+++ b/KeyManager.Library.KeyStore.SAM_SE/SAM_SEKeyStore.cs
@@ -176,8 +176,17 @@ namespace Leosac.KeyManager.Library.KeyStore.SAM_SE
                         }
                     }
                 }
-                //Update enabled conf depending on the linked objects
-                UpdateConfEnabled();
+                try
+                {
+                    //Update enabled conf depending on the linked objects
+                    UpdateConfEnabled();
+                }
+                catch (KeyStoreException)
+                {
+                    //Do nothing. This try catch is just here to not throw an error when the user opens
+                    //KeyManager with a not up-to-date SAM-SE (v1.6.0) and gets an error right away ...
+                }
+
             }
 
             log.Info(String.Format("{0} key entries returned.", entries.Count));

--- a/KeyManager.Library.KeyStore.SAM_SE/SAM_SEKeyStoreFactory.cs
+++ b/KeyManager.Library.KeyStore.SAM_SE/SAM_SEKeyStoreFactory.cs
@@ -15,7 +15,7 @@ namespace Leosac.KeyManager.Library.KeyStore.SAM_SE
     public class SAM_SEKeyStoreFactory : KeyStoreFactory
     {
         private readonly uint MAJOR = 1;
-        private readonly uint MINOR = 2;
+        private readonly uint MINOR = 3;
         private readonly uint DVL = 0;
         private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
 


### PR DESCRIPTION
Corrections :
* An error was occurring when the user tried to open a SAM-SE Key Store with a none up-to-date SAM-SE (v1.6.0) : It was still recoverable by doing a manual operation using the Tools menu to update the SAM-SE